### PR TITLE
Add Makefile with container helper tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+# Helper Makefile for development
+
+CONTAINER ?= app_mov-dinero
+DB_CONTAINER ?= db_mov-dinero
+
+# Run a command inside the main container
+run:
+	docker exec -it $(CONTAINER) $(filter-out $@,$(MAKECMDGOALS))
+
+# Basic commands
+up:
+	docker compose up --build -d
+
+down:
+	docker compose down
+
+down-v:
+	docker compose down -v
+
+logs:
+	docker compose logs -f || true
+
+logs-db:
+	docker logs -f $(DB_CONTAINER) || true
+
+shell:
+	docker exec -it $(CONTAINER) /bin/bash
+
+prune:
+	docker system prune
+
+rebuild:
+	make down
+	make up
+
+start:
+	docker start $(CONTAINER)
+
+stop:
+	docker stop $(CONTAINER)
+
+restart:
+	docker restart $(CONTAINER)
+
+ps:
+	docker ps
+
+push:
+	git add .
+	git commit -m "$(word 2, $(MAKECMDGOALS))"
+	git push
+
+pull:
+	git pull origin main
+
+# Allow targets with arguments at the end
+%:
+	@:


### PR DESCRIPTION
## Summary
- add helper Makefile to manage docker containers
- include commands for up, down, pruning, logs and container lifecycle
- rename restart to `rebuild` and add `start`, `stop` and `restart` commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e5cf9ffc83329ac6bafd29bd27c9