### PR TITLE
Configure DB volume path via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=movdb
 POSTGRES_PORT=5432
 DATABASE_URL=postgresql+psycopg2://postgres:postgres@db_mov-dinero:5432/movdb
+DB_PATH=./postgres_data
 
 JWT_SECRET_KEY=changeme
 JWT_ALGORITHM=HS256

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Backend en FastAPI para registrar movimientos entre cuentas.
 ## Desarrollo
 
 
-1. Copia `.env.example` a `.env` y ajusta los valores de la base de datos y JWT.
+1. Copia `.env.example` a `.env` y ajusta los valores de la base de datos, `DB_PATH` y JWT.
 
 2. Ejecuta:
    ```
@@ -16,4 +16,7 @@ Backend en FastAPI para registrar movimientos entre cuentas.
    ```
 
 3. La aplicación se une a dos redes: `movdin_net` para comunicarse con la base y `nginx_net` para tu proxy.
+
+4. Configura `DB_PATH` en el archivo `.env` para elegir la ruta donde se guardará
+   el volumen de PostgreSQL.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     env_file:
       - .env
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - ${DB_PATH:-./postgres_data}:/var/lib/postgresql/data
     ports:
       - "6432:5432"
     networks:


### PR DESCRIPTION
## Summary
- mount DB data volume using `DB_PATH` from `.env`
- add `DB_PATH` placeholder to `.env.example`
- document new setting in README

## Testing
- `python -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_6884162a96f083329e92568447375d5c