### PR TITLE
Implement manual registration flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=movdb
@@ -13,10 +12,14 @@ ACCESS_TOKEN_EXPIRE_MINUTES=30
 # Default admin credentials
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin
+ADMIN_EMAIL=admin@example.com
 
 # Google OAuth
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
-#Mailer en red docker mailer_net
-MAILER_TOKEN="op03LSXÑ!q'M2$eSXOA=?QW,W"
+# Mailer en red docker mailer_net
+MAILER_URL=http://mailer:3322/send
+MAILER_TOKEN="your-mailer-token"
+MAILER_FROM=no-reply@gabo.ar
+BASE_URL=http://localhost:8000

--- a/app/api/routers/__init__.py
+++ b/app/api/routers/__init__.py
@@ -1,3 +1,3 @@
-from . import auth, users, accounts, movements, dashboard
+from . import auth, users, accounts, movements, dashboard, registration
 
-__all__ = ["auth", "users", "accounts", "movements", "dashboard"]
+__all__ = ["auth", "users", "accounts", "movements", "dashboard", "registration"]

--- a/app/api/routers/registration.py
+++ b/app/api/routers/registration.py
@@ -1,0 +1,82 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from uuid import uuid4
+
+from app.database import get_db
+from app import models
+from app.schemas.registration import RegistrationCreate, RegistrationRead
+from app.core.config import get_settings
+from app.services.mailer import send_email
+
+router = APIRouter(prefix="/registrations", tags=["registrations"])
+settings = get_settings()
+
+
+@router.post('/', response_model=RegistrationRead)
+def create_registration(reg_in: RegistrationCreate, db: Session = Depends(get_db)):
+    reg = models.Registration(
+        first_name=reg_in.first_name,
+        last_name=reg_in.last_name,
+        email=reg_in.email,
+        admin_token=str(uuid4()),
+        user_token=str(uuid4()),
+    )
+    db.add(reg)
+    db.commit()
+    db.refresh(reg)
+
+    approve_link = f"{settings.base_url}/registrations/{reg.id}/approve?token={reg.admin_token}"
+    reject_link = f"{settings.base_url}/registrations/{reg.id}/reject?token={reg.admin_token}"
+    body = (
+        f"<p>Nuevo registro de {reg.first_name} {reg.last_name} ({reg.email}).</p>"
+        f"<p><a href='{approve_link}'>Aprobar</a> | <a href='{reject_link}'>Rechazar</a></p>"
+    )
+    send_email(settings.admin_email, "Nuevo registro", body)
+    return reg
+
+
+@router.get('/{reg_id}/approve')
+def approve_registration(reg_id: int, token: str, db: Session = Depends(get_db)):
+    reg = db.query(models.Registration).filter(models.Registration.id == reg_id).first()
+    if not reg or reg.admin_token != token or reg.rejected:
+        raise HTTPException(status_code=404, detail="Invalid registration")
+    reg.approved = True
+    db.commit()
+    confirm_link = f"{settings.base_url}/registrations/{reg.id}/confirm?token={reg.user_token}"
+    body = (
+        f"<p>Su registro fue aprobado.</p>"
+        f"<p><a href='{confirm_link}'>Confirmar cuenta</a></p>"
+    )
+    send_email(reg.email, "Registro aprobado", body)
+    return {"ok": True}
+
+
+@router.get('/{reg_id}/reject')
+def reject_registration(reg_id: int, token: str, db: Session = Depends(get_db)):
+    reg = db.query(models.Registration).filter(models.Registration.id == reg_id).first()
+    if not reg or reg.admin_token != token or reg.approved:
+        raise HTTPException(status_code=404, detail="Invalid registration")
+    reg.rejected = True
+    db.commit()
+    send_email(reg.email, "Registro rechazado", "<p>Su registro fue rechazado.</p>")
+    return {"ok": True}
+
+
+@router.get('/{reg_id}/confirm')
+def confirm_registration(reg_id: int, token: str, db: Session = Depends(get_db)):
+    reg = db.query(models.Registration).filter(models.Registration.id == reg_id).first()
+    if not reg or reg.user_token != token or not reg.approved or reg.rejected:
+        raise HTTPException(status_code=404, detail="Invalid registration")
+    if reg.confirmed:
+        return {"detail": "Already confirmed"}
+    user = models.User(
+        username=reg.email,
+        email=reg.email,
+        first_name=reg.first_name,
+        last_name=reg.last_name,
+    )
+    db.add(user)
+    reg.confirmed = True
+    db.commit()
+    send_email(reg.email, "Cuenta creada", "<p>Su cuenta ha sido creada.</p>")
+    return {"ok": True}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -11,8 +11,13 @@ class Settings(BaseSettings):
     postgres_port: int
     admin_username: str
     admin_password: str
+    admin_email: str
     google_client_id: str
     google_client_secret: str
+    mailer_token: str
+    mailer_url: str
+    mailer_from: str = 'no-reply@gabo.ar'
+    base_url: str
 
     JWT_ALGORITHM: str = 'HS256'
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from app.api.routers import auth, users, accounts, movements, dashboard
+from app.api.routers import auth, users, accounts, movements, dashboard, registration
 from app.database import Base, engine
 from app.services.logging_middleware import LoggingMiddleware
 from pathlib import Path
@@ -22,3 +22,4 @@ app.include_router(users.router)
 app.include_router(accounts.router)
 app.include_router(movements.router)
 app.include_router(dashboard.router)
+app.include_router(registration.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,3 +2,4 @@ from .user import User
 from .account import Account
 from .movement import Movement, MovementType
 from .base import Base
+from .registration import Registration

--- a/app/models/registration.py
+++ b/app/models/registration.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String, Boolean
+from .base import Base
+
+class Registration(Base):
+    id = Column(Integer, primary_key=True, index=True)
+    first_name = Column(String, nullable=False)
+    last_name = Column(String, nullable=False)
+    email = Column(String, unique=True, nullable=False)
+    admin_token = Column(String, unique=True, nullable=False)
+    user_token = Column(String, unique=True, nullable=False)
+    approved = Column(Boolean, default=False)
+    rejected = Column(Boolean, default=False)
+    confirmed = Column(Boolean, default=False)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, Boolean
 from sqlalchemy.orm import relationship
 
 from .base import Base
@@ -6,7 +6,11 @@ from .base import Base
 class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, unique=True, index=True, nullable=False)
-    hashed_password = Column(String, nullable=False)
+    hashed_password = Column(String, nullable=True)
+    first_name = Column(String, nullable=True)
+    last_name = Column(String, nullable=True)
+    email = Column(String, unique=True, index=True, nullable=True)
+    is_active = Column(Boolean, default=True)
 
     movements = relationship('Movement', back_populates='user')
     accounts = relationship('Account', back_populates='user')

--- a/app/schemas/registration.py
+++ b/app/schemas/registration.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, EmailStr
+
+class RegistrationCreate(BaseModel):
+    first_name: str
+    last_name: str
+    email: EmailStr
+
+class RegistrationRead(BaseModel):
+    id: int
+    first_name: str
+    last_name: str
+    email: EmailStr
+    approved: bool
+    rejected: bool
+    confirmed: bool
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -2,11 +2,17 @@ from pydantic import BaseModel
 
 class UserCreate(BaseModel):
     username: str
-    password: str
+    password: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+    email: str | None = None
 
 class UserRead(BaseModel):
     id: int
     username: str
+    first_name: str | None = None
+    last_name: str | None = None
+    email: str | None = None
 
     class Config:
         orm_mode = True

--- a/app/services/mailer.py
+++ b/app/services/mailer.py
@@ -1,0 +1,21 @@
+import requests
+from app.core.config import get_settings
+
+settings = get_settings()
+
+
+def send_email(to: str, subject: str, body: str, from_address: str | None = None):
+    payload = {
+        'to': to,
+        'subject': subject,
+        'body': body,
+        'from': from_address or settings.mailer_from,
+    }
+    headers = {
+        'Authorization': f'Bearer {settings.mailer_token}',
+        'Content-Type': 'application/json',
+    }
+    try:
+        requests.post(settings.mailer_url, json=payload, headers=headers, timeout=5)
+    except Exception as exc:
+        print(f'Error sending email: {exc}')

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,9 +3,15 @@ import { useState } from 'react'
 import './App.css'
 
 function App() {
+  const [page, setPage] = useState('login')
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
+
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState('')
 
   const handleSubmit = (e) => {
     e.preventDefault()
@@ -17,38 +23,99 @@ function App() {
     // TODO: implementar login
   }
 
+  const handleRegister = async (e) => {
+    e.preventDefault()
+    if (!firstName || !lastName || !email) {
+      setMessage('Completa todos los campos')
+      return
+    }
+    setMessage('')
+    try {
+      const res = await fetch('/registrations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ first_name: firstName, last_name: lastName, email })
+      })
+      if (res.ok) {
+        setMessage('Registro enviado')
+        setFirstName(''); setLastName(''); setEmail('')
+      } else {
+        setMessage('Error al registrar')
+      }
+    } catch (err) {
+      setMessage('Error al registrar')
+    }
+  }
+
   return (
     <div className="d-flex flex-column justify-content-start align-items-center min-vh-100 pt-5">
-      <div className="login-container d-flex flex-column align-items-center mt-5">
-        <div className="text-end w-100 mb-3">
-          <a href="#">Registrarse</a>
+      {page === 'login' ? (
+        <div className="login-container d-flex flex-column align-items-center mt-5">
+          <div className="text-end w-100 mb-3">
+            <a href="#" onClick={() => setPage('register')}>Registrarse</a>
+          </div>
+          <form onSubmit={handleSubmit} className="d-flex flex-column gap-3 w-100">
+            <h2 className="text-center">Iniciar Sesión</h2>
+            {error && <div className="alert alert-danger py-2">{error}</div>}
+            <input
+              type="text"
+              className="form-control"
+              placeholder="Usuario"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+            <input
+              type="password"
+              className="form-control"
+              placeholder="Contraseña"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <button type="submit" className="btn btn-secondary w-100">
+              Ingresar
+            </button>
+            <button type="button" className="btn btn-outline-primary w-100">
+              Ingresar con Google
+            </button>
+          </form>
+          <img src="/logo_ta.png" alt="Logo" className="logo" />
         </div>
-        <form onSubmit={handleSubmit} className="d-flex flex-column gap-3 w-100">
-          <h2 className="text-center">Iniciar Sesión</h2>
-          {error && <div className="alert alert-danger py-2">{error}</div>}
-          <input
-            type="text"
-            className="form-control"
-            placeholder="Usuario"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-          />
-          <input
-            type="password"
-            className="form-control"
-            placeholder="Contraseña"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          <button type="submit" className="btn btn-secondary w-100">
-            Ingresar
-          </button>
-          <button type="button" className="btn btn-outline-primary w-100">
-            Ingresar con Google
-          </button>
-        </form>
-        <img src="/logo_ta.png" alt="Logo" className="logo" />
-      </div>
+      ) : (
+        <div className="login-container d-flex flex-column align-items-center mt-5">
+          <div className="text-end w-100 mb-3">
+            <a href="#" onClick={() => setPage('login')}>Volver</a>
+          </div>
+          <form onSubmit={handleRegister} className="d-flex flex-column gap-3 w-100">
+            <h2 className="text-center">Registrarse</h2>
+            {message && <div className="alert alert-info py-2">{message}</div>}
+            <input
+              type="text"
+              className="form-control"
+              placeholder="Nombre"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+            />
+            <input
+              type="text"
+              className="form-control"
+              placeholder="Apellido"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+            />
+            <input
+              type="email"
+              className="form-control"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <button type="submit" className="btn btn-secondary w-100">
+              Enviar registro
+            </button>
+          </form>
+          <img src="/logo_ta.png" alt="Logo" className="logo" />
+        </div>
+      )}
     </div>
   )
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-jose
 passlib[bcrypt]
 python-dotenv
 python-multipart
+requests


### PR DESCRIPTION
## Summary
- add mailer token & admin email to `.env.example`
- extend config with mailer, admin email, and base url
- add mailer service helper
- define `Registration` model and schemas
- add registration router with admin approval and user confirmation
- extend user model and schema to include personal info
- wire up registration router in the application
- create registration form in React
- update requirements
- make mailer URL and sender configurable

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files "*.py")`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886b8669d0c83328062666f30f43873