### PR TITLE
Add password confirmation on signup

### DIFF
--- a/app/api/routers/registration.py
+++ b/app/api/routers/registration.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 from app.database import get_db
 from app import models
 from app.schemas.registration import RegistrationCreate, RegistrationRead
+from app.core.security import get_password_hash
 from app.core.config import get_settings
 from app.services.mailer import send_email
 
@@ -18,6 +19,7 @@ def create_registration(reg_in: RegistrationCreate, db: Session = Depends(get_db
         first_name=reg_in.first_name,
         last_name=reg_in.last_name,
         email=reg_in.email,
+        hashed_password=get_password_hash(reg_in.password),
         admin_token=str(uuid4()),
         user_token=str(uuid4()),
     )
@@ -74,6 +76,7 @@ def confirm_registration(reg_id: int, token: str, db: Session = Depends(get_db))
         email=reg.email,
         first_name=reg.first_name,
         last_name=reg.last_name,
+        hashed_password=reg.hashed_password,
     )
     db.add(user)
     reg.confirmed = True

--- a/app/models/registration.py
+++ b/app/models/registration.py
@@ -8,6 +8,7 @@ class Registration(Base):
     email = Column(String, unique=True, nullable=False)
     admin_token = Column(String, unique=True, nullable=False)
     user_token = Column(String, unique=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
     approved = Column(Boolean, default=False)
     rejected = Column(Boolean, default=False)
     confirmed = Column(Boolean, default=False)

--- a/app/schemas/registration.py
+++ b/app/schemas/registration.py
@@ -4,6 +4,7 @@ class RegistrationCreate(BaseModel):
     first_name: str
     last_name: str
     email: EmailStr
+    password: str
 
 class RegistrationRead(BaseModel):
     id: int

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,8 @@ function App() {
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
   const [email, setEmail] = useState('')
+  const [regPassword, setRegPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
   const [message, setMessage] = useState('')
 
   const handleSubmit = (e) => {
@@ -25,8 +27,12 @@ function App() {
 
   const handleRegister = async (e) => {
     e.preventDefault()
-    if (!firstName || !lastName || !email) {
+    if (!firstName || !lastName || !email || !regPassword || !confirmPassword) {
       setMessage('Completa todos los campos')
+      return
+    }
+    if (regPassword !== confirmPassword) {
+      setMessage('Las contraseñas no coinciden')
       return
     }
     setMessage('')
@@ -34,15 +40,15 @@ function App() {
       const res = await fetch('/registrations', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ first_name: firstName, last_name: lastName, email })
+        body: JSON.stringify({ first_name: firstName, last_name: lastName, email, password: regPassword })
       })
       if (res.ok) {
         setMessage('Registro enviado')
-        setFirstName(''); setLastName(''); setEmail('')
+        setFirstName(''); setLastName(''); setEmail(''); setRegPassword(''); setConfirmPassword('')
       } else {
         setMessage('Error al registrar')
       }
-    } catch (err) {
+    } catch {
       setMessage('Error al registrar')
     }
   }
@@ -108,6 +114,20 @@ function App() {
               placeholder="Email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
+            />
+            <input
+              type="password"
+              className="form-control"
+              placeholder="Contraseña"
+              value={regPassword}
+              onChange={(e) => setRegPassword(e.target.value)}
+            />
+            <input
+              type="password"
+              className="form-control"
+              placeholder="Repetir Contraseña"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
             />
             <button type="submit" className="btn btn-secondary w-100">
               Enviar registro


### PR DESCRIPTION
## Summary
- ask for password twice in registration form
- store hashed password during registration
- carry password into user account upon confirmation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6886d388a828833296388c17d2dc239f