### PR TITLE
Fix registration endpoint path

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,7 +37,7 @@ function App() {
     }
     setMessage('')
     try {
-      const res = await fetch('/registrations', {
+      const res = await fetch('/registrations/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ first_name: firstName, last_name: lastName, email, password: regPassword })


### PR DESCRIPTION
## Summary
- ensure frontend POSTs to `/registrations/` to avoid 405 error

## Testing
- `npm run build`
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6886e0c6bc648332a8d869565e80738e