### PR TITLE
Fix 405 on /registrations by mounting static app after routers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,14 +12,14 @@ app = FastAPI(title="Movimientos de Dinero")
 app.add_middleware(LoggingMiddleware)
 
 
-app.mount(
-    "/",
-    StaticFiles(directory=Path(__file__).parent.parent / "frontend" / "dist", html=True),
-    name="frontend"
-)
 app.include_router(auth.router)
 app.include_router(users.router)
 app.include_router(accounts.router)
 app.include_router(movements.router)
 app.include_router(dashboard.router)
 app.include_router(registration.router)
+app.mount(
+    "/",
+    StaticFiles(directory=Path(__file__).parent.parent / "frontend" / "dist", html=True),
+    name="frontend"
+)


### PR DESCRIPTION
## Summary
- move `app.mount()` to be registered after all routers

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_688842e0123083329226258a076f0214