### PR TITLE
Add order detail modal with processing and finalize actions

### DIFF
--- a/frontend/src/components/orders/OrderDetails.jsx
+++ b/frontend/src/components/orders/OrderDetails.jsx
@@ -1,0 +1,54 @@
+function OrderDetails({ order, onClose, onEdit, onProcess, onFinalize }) {
+  return (
+    <div className="position-fixed top-0 start-0 w-100 h-100 bg-dark bg-opacity-50 d-flex align-items-center justify-content-center">
+      <div
+        className="bg-white p-4 rounded w-100"
+        style={{ maxWidth: '600px', maxHeight: '90vh', overflowY: 'auto', position: 'relative' }}
+      >
+        <button
+          type="button"
+          className="btn-close position-absolute top-0 end-0 m-2"
+          onClick={onClose}
+        ></button>
+        <h5>Detalles de la orden</h5>
+        <div className="mt-3">
+          <p>
+            <strong>Cliente:</strong> {order.client}
+          </p>
+          <p>
+            <strong>Teléfono:</strong> {order.phone}
+          </p>
+          <p>
+            <strong>Dirección:</strong> {order.address}
+          </p>
+          <p>
+            <strong>Estado:</strong> {order.status}
+          </p>
+          {order.notes && (
+            <p>
+              <strong>Observaciones:</strong> {order.notes}
+            </p>
+          )}
+        </div>
+        <div className="mt-4 d-flex flex-column gap-3">
+          <button className="btn btn-success w-100" onClick={onFinalize}>
+            Finalizar
+          </button>
+          <div>
+            <p className="text-muted mb-1">
+              Procesar la orden se entiende que ya está en taller para fabricar.
+            </p>
+            <button className="btn btn-primary w-100" onClick={onProcess}>
+              Procesar
+            </button>
+          </div>
+          <button className="btn btn-secondary w-100" onClick={onEdit}>
+            Editar
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default OrderDetails

--- a/frontend/src/pages/orders/OrdersView.jsx
+++ b/frontend/src/pages/orders/OrdersView.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import OrderCard from '../../components/orders/OrderCard'
 import OrderSearch from '../../components/orders/OrderSearch'
 import OrderForm from '../../components/orders/OrderForm'
+import OrderDetails from '../../components/orders/OrderDetails'
 
 function OrdersView() {
   const initialOrders = [
@@ -65,6 +66,7 @@ function OrdersView() {
   const [search, setSearch] = useState('')
   const [showForm, setShowForm] = useState(false)
   const [editingOrder, setEditingOrder] = useState(null)
+  const [selectedOrder, setSelectedOrder] = useState(null)
 
   const filteredOrders = orders.filter((o) => {
     const term = search.toLowerCase()
@@ -84,13 +86,12 @@ function OrdersView() {
     }
   }
 
-  const handleEdit = (order) => {
-    setEditingOrder(order)
-    setShowForm(true)
+  const handleStatusChange = (id, status) => {
+    setOrders((prev) => prev.map((o) => (o.id === id ? { ...o, status } : o)))
   }
 
   return (
-    <div className="container py-4">
+    <div className="container-fluid py-4 px-5">
       <div className="d-flex justify-content-between align-items-center mb-3">
         <h2>Órdenes de trabajo</h2>
         <div>
@@ -113,7 +114,7 @@ function OrdersView() {
           {filteredOrders
             .filter((o) => o.status === 'ingresado')
             .map((o) => (
-              <OrderCard key={o.id} order={o} onClick={() => handleEdit(o)} />
+              <OrderCard key={o.id} order={o} onClick={() => setSelectedOrder(o)} />
             ))}
         </div>
         <div className="col-md-6">
@@ -121,10 +122,30 @@ function OrdersView() {
           {filteredOrders
             .filter((o) => o.status === 'en_proceso')
             .map((o) => (
-              <OrderCard key={o.id} order={o} onClick={() => handleEdit(o)} />
+              <OrderCard key={o.id} order={o} onClick={() => setSelectedOrder(o)} />
             ))}
         </div>
       </div>
+      {selectedOrder && (
+        <OrderDetails
+          order={selectedOrder}
+          onClose={() => setSelectedOrder(null)}
+          onEdit={() => {
+            setEditingOrder(selectedOrder)
+            setShowForm(true)
+            setSelectedOrder(null)
+          }}
+          onProcess={() => {
+            handleStatusChange(selectedOrder.id, 'en_proceso')
+            setSelectedOrder(null)
+          }}
+          onFinalize={() => {
+            handleStatusChange(selectedOrder.id, 'finalizado')
+            setSelectedOrder(null)
+          }}
+        />
+      )}
+
       {showForm && (
         <OrderForm
           order={editingOrder}


### PR DESCRIPTION
## Summary
- show order detail modal with finalize, process and edit buttons
- adjust orders view to open detail modal and update statuses
- expand order listing container to widescreen width

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689512d043e48332bb99c508daa625df