### PR TITLE
Ensure models loaded before metadata creation

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,15 +1,13 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from .core.config import get_settings
+from app.models.base import Base
 
 settings = get_settings()
 
 engine = create_engine(settings.DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-Base = declarative_base()
 
 
 def get_db():

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from app.api.routers import auth, users, accounts, movements, dashboard, registr
 from app.database import Base, engine
 from app.services.logging_middleware import LoggingMiddleware
 from pathlib import Path
+import app.models
 
 Base.metadata.create_all(bind=engine)
 


### PR DESCRIPTION
## Summary
- Import shared `Base` from `app.models.base` and remove local `declarative_base`.
- Load `app.models` prior to `Base.metadata.create_all` to ensure table creation.

## Testing
- `python - <<'PY'
from app.main import app
from app.database import engine
from sqlalchemy import inspect
inspector = inspect(engine)
print(sorted(inspector.get_table_names()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68954636a09c8332ab886a1568b9fedd