### PR TITLE
feat: persist session and authorize order requests

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -3,13 +3,21 @@ import { createContext, useContext, useState } from 'react'
 const AuthContext = createContext()
 
 export function AuthProvider({ children }) {
-  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [token, setToken] = useState(() => localStorage.getItem('token'))
+  const isAuthenticated = Boolean(token)
 
-  const login = () => setIsAuthenticated(true)
-  const logout = () => setIsAuthenticated(false)
+  const login = (newToken) => {
+    setToken(newToken)
+    localStorage.setItem('token', newToken)
+  }
+
+  const logout = () => {
+    setToken(null)
+    localStorage.removeItem('token')
+  }
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+    <AuthContext.Provider value={{ isAuthenticated, token, login, logout }}>
       {children}
     </AuthContext.Provider>
   )

--- a/frontend/src/pages/AuthPage.jsx
+++ b/frontend/src/pages/AuthPage.jsx
@@ -19,18 +19,32 @@ function AuthPage() {
   const navigate = useNavigate()
   const { login } = useAuth()
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
     if (!username || !password) {
       setError('Completa todos los campos')
       return
     }
     setError('')
-    login()
-    navigate('/welcome')
+    try {
+      const res = await fetch('/auth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ username, password }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        login(data.access_token)
+        navigate('/welcome')
+      } else {
+        setError('Usuario o contraseña incorrectos')
+      }
+    } catch {
+      setError('Error de conexión')
+    }
   }
 
-  const handleRegister = (e) => {
+  const handleRegister = async (e) => {
     e.preventDefault()
     if (!firstName || !lastName || !email || !regPassword || !confirmPassword) {
       setMessage('Completa todos los campos')
@@ -41,8 +55,27 @@ function AuthPage() {
       return
     }
     setMessage('')
-    login()
-    navigate('/welcome')
+    try {
+      const res = await fetch('/users/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username: email,
+          password: regPassword,
+          first_name: firstName,
+          last_name: lastName,
+          email,
+        }),
+      })
+      if (res.ok) {
+        setMessage('Cuenta creada, ahora puedes iniciar sesión')
+        setPage('login')
+      } else {
+        setMessage('No se pudo crear la cuenta')
+      }
+    } catch {
+      setMessage('Error de conexión')
+    }
   }
 
   return (

--- a/frontend/src/pages/orders/OrdersView.jsx
+++ b/frontend/src/pages/orders/OrdersView.jsx
@@ -3,6 +3,7 @@ import OrderCard from '../../components/orders/OrderCard'
 import OrderSearch from '../../components/orders/OrderSearch'
 import OrderForm from '../../components/orders/OrderForm'
 import OrderDetails from '../../components/orders/OrderDetails'
+import { useAuth } from '../../context/AuthContext'
 
 function OrdersView() {
   const [orders, setOrders] = useState([])
@@ -10,11 +11,14 @@ function OrdersView() {
   const [showForm, setShowForm] = useState(false)
   const [editingOrder, setEditingOrder] = useState(null)
   const [selectedOrder, setSelectedOrder] = useState(null)
+  const { token } = useAuth()
 
   useEffect(() => {
     const fetchOrders = async () => {
       try {
-        const res = await fetch('/orders')
+        const res = await fetch('/orders', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
         if (res.ok) {
           const data = await res.json()
           setOrders(data)
@@ -26,8 +30,8 @@ function OrdersView() {
       }
     }
 
-    fetchOrders()
-  }, [])
+    if (token) fetchOrders()
+  }, [token])
 
   const filteredOrders = orders.filter((o) => {
     const term = search.toLowerCase()
@@ -43,7 +47,10 @@ function OrdersView() {
       const isEditing = Boolean(order.id)
       const res = await fetch(isEditing ? `/orders/${order.id}` : '/orders', {
         method: isEditing ? 'PUT' : 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify(order),
       })
       if (res.ok) {
@@ -68,7 +75,10 @@ function OrdersView() {
     try {
       const res = await fetch(`/orders/${id}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({ ...order, status }),
       })
       if (res.ok) {


### PR DESCRIPTION
## Summary
- persist auth token in localStorage and expose through context
- implement backend login and registration requests
- send bearer token when listing or modifying orders
- seed default admin user from environment and allow direct user signup

## Testing
- `npm --prefix frontend test` *(fails: Missing script "test")*
- `npm --prefix frontend run lint`
- `pytest` *(0 tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689554e8f6e483329a8aa6553a7caf9a